### PR TITLE
Add Firestore listener cleanup

### DIFF
--- a/src/components/PlanningBoard.vue
+++ b/src/components/PlanningBoard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, onUnmounted } from 'vue';
 import { collection, onSnapshot, doc, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 
@@ -16,14 +16,20 @@ const days = ref([]); // array of dates as strings
 const planning = ref({}); // {day: {collabId: {status, time, location}}}
 const selectedDay = ref('');
 
+let unsubscribeCollaborators;
+let unsubscribePlanning;
+
 onMounted(() => {
   // listen to collaborators
-  onSnapshot(collection(db, 'collaborators'), (snapshot) => {
-    collaborators.value = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
-  });
+  unsubscribeCollaborators = onSnapshot(
+    collection(db, 'collaborators'),
+    (snapshot) => {
+      collaborators.value = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+    }
+  );
 
   // listen to planning days
-  onSnapshot(collection(db, 'planning'), (snapshot) => {
+  unsubscribePlanning = onSnapshot(collection(db, 'planning'), (snapshot) => {
     const data = {};
     const dayList = [];
     snapshot.forEach((docSnap) => {
@@ -36,6 +42,15 @@ onMounted(() => {
       selectedDay.value = days.value[0];
     }
   });
+});
+
+onUnmounted(() => {
+  if (typeof unsubscribeCollaborators === 'function') {
+    unsubscribeCollaborators();
+  }
+  if (typeof unsubscribePlanning === 'function') {
+    unsubscribePlanning();
+  }
 });
 
 function filteredCollaborators() {


### PR DESCRIPTION
## Summary
- implement `onUnmounted` lifecycle hook in PlanningBoard
- store and call unsubscribe functions returned by Firestore listeners

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68716f81cfc083268b585bc881858822