### PR TITLE
Enhance CSS contrast

### DIFF
--- a/src/components/PlanningBoard.vue
+++ b/src/components/PlanningBoard.vue
@@ -211,12 +211,13 @@ async function addClient() {
   justify-content: center;
   cursor: pointer;
   font-size: 0.8rem;
+  color: #333;
 }
 .cell.dispo {
-  background-color: #d4edda;
+  background-color: #c6f6d5;
 }
 .cell.indispo {
-  background-color: #f8d7da;
+  background-color: #fecaca;
 }
 .search-bar {
   padding: 8px;

--- a/src/style.css
+++ b/src/style.css
@@ -3,9 +3,10 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  /* Always use a light background so status colors are visible */
+  color-scheme: light;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -65,15 +66,16 @@ button:focus-visible {
   text-align: center;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color-scheme: dark;
+    color: rgba(255, 255, 255, 0.87);
+    background-color: #242424;
+  }
+  button {
+    background-color: #1a1a1a;
   }
   a:hover {
     color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
   }
 }


### PR DESCRIPTION
## Summary
- use light theme by default so colors stand out
- add dark theme override
- improve cell colors and text visibility

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68717d615fd8832692b9be37a1619f93