### PR TITLE
Improve planning board status colors

### DIFF
--- a/src/components/PlanningBoard.vue
+++ b/src/components/PlanningBoard.vue
@@ -221,13 +221,17 @@ async function addClient() {
   box-shadow: inset 0 0 0 1px #e5e5e5;
 }
 .cell.dispo {
-  background-color: #c6f6d5;
+  background-color: var(--status-dispo);
+  color: #1b1b1b;
+  border: 1px solid #16a34a;
 }
 .cell.indispo {
-  background-color: #fecaca;
+  background-color: var(--status-indispo);
+  color: #fff;
+  border: 1px solid #dc2626;
 }
 .cell:hover {
-  filter: brightness(0.95);
+  filter: brightness(1.05);
 }
 .search-bar {
   padding: 8px;

--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
+  --status-dispo: #4ade80;
+  --status-indispo: #f87171;
+
   /* Always use a light background so status colors are visible */
   color-scheme: light;
   color: #213547;
@@ -71,6 +74,8 @@ button:focus-visible {
     color-scheme: dark;
     color: rgba(255, 255, 255, 0.87);
     background-color: #242424;
+    --status-dispo: #4ade80;
+    --status-indispo: #f87171;
   }
   button {
     background-color: #334155;


### PR DESCRIPTION
## Summary
- enhance `.cell.dispo` and `.cell.indispo` styling
- add CSS variables for status colors

## Testing
- `yarn install`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687182f1d254832681c97dd9a8823f13